### PR TITLE
Added rules for Ubuntu's Uncomplicated FireWall (UFW)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Testing rules
-When developing a regex you probably need to test it more ofthen than you want.
+When developing a regex you probably need to test it more often than you want.
 
 ### Console
 Use the following line to test the logcheck regular expressions.

--- a/ignore.d.server/local-ufw
+++ b/ignore.d.server/local-ufw
@@ -1,0 +1,7 @@
+# Rules for Ubuntu's Uncomplicated FireWall (UFW)
+
+# TCP blocks
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ kernel: \[[[:digit:].]+\] \[UFW BLOCK\] IN=[[:alnum:]]+ OUT= MAC=[[:xdigit:]:]+ SRC=[.[:digit:]]{7,15} DST=[.[:digit:]]{7,15} LEN=[[:digit:]]+ TOS=0x[[:xdigit:]]+ PREC=0x[[:xdigit:]]+ TTL=[[:digit:]]+ ID=[[:digit:]]+ (DF )?PROTO=TCP SPT=[[:digit:]]+ DPT=[[:digit:]]+ WINDOW=[[:digit:]]+ RES=0x[[:xdigit:]]+ SYN URGP=[[:digit:]]+$
+
+# UDP blocks
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ kernel: \[[[:digit:].]+\] \[UFW BLOCK\] IN=[[:alnum:]]+ OUT= MAC=[[:xdigit:]:]+ SRC=[.[:digit:]]{7,15} DST=[.[:digit:]]{7,15} LEN=[[:digit:]]+ TOS=0x[[:xdigit:]]+ PREC=0x[[:xdigit:]]+ TTL=[[:digit:]]+ ID=[[:digit:]]+ (DF )?PROTO=UDP SPT=[[:digit:]]+ DPT=[[:digit:]]+ LEN=[[:digit:]]+$


### PR DESCRIPTION
Hi! I had the need of ignoring very common firewall rules, since any server exposed to the internet will be exposed to TCP / UDP connections that will be blocked. As this is expected, some people recommend just ignoring these warnings.

Some people also recommend turning off UFW's logging altogether, but even if that's done, having this rule for logcheck wouldn't hurt.

Thanks!