### PR TITLE
Added local-do-agent for DigitalOcean hosts

### DIFF
--- a/ignore.d.server/local-do-agent
+++ b/ignore.d.server/local-do-agent
@@ -1,0 +1,8 @@
+# Checking for newer version of do-agent
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ do-agent\[[[:digit:]]+\]: [[:digit:]\/ :]{19} Checking for newer version of do-agent$
+
+# No update available
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ do-agent\[[[:digit:]]+\]: [[:digit:]\/ :]{19} No update available$
+
+# No repository update available
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ do-agent\[[[:digit:]]+\]: [[:digit:]\/ :]{19} No repository update available$


### PR DESCRIPTION
This is a file that will ignore logs from a Digital Ocean included service in their Linux hosts. The service is called `do-agent` and will just basically keep the system under monitoring for DigitalOcean.

There are three entry lines being ignored here:

- `Checking for newer version of do-agent`, when the system checks for a newer version of the agent. Since this is just checking (and it is expected), I believe it can be ignored.
- `No update available`, after the first line, this one indicates that the agent did not find any update so it's not going to do anything
- `No repository update available`, similar to the above line

There are other logs that it will output, but I chose to keep those in logcheck since they may be indicative of a problem. I don't remember the exact lines but they signal the following problems:

- Issues contacting the repository
- Data sent to DigitalOcean, and what the response was (either failure or success)
- Update is available and the agent updates