### PR TITLE
small improvements on snapd regex

### DIFF
--- a/ignore.d.server/local-snapd
+++ b/ignore.d.server/local-snapd
@@ -1,3 +1,4 @@
 # 16.0.4.2 snapd
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ /usr/lib/snapd/snapd\[[0-9]+\]: snapmgr.go:[0-9]+: No snaps to auto-refresh found$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ snapd\[[0-9]+\]: [\/0-9]{10} [:0-9]{8}\.[0-9]+ snapmgr.go:[0-9]+: No snaps to auto-refresh found$
+^\w{3} [ :0-9]{11} [._[:alnum:]-]+ /usr/lib/snapd/snapd\[[0-9]+\]: snapmgr.go:[0-9]+: DEBUG: Next refresh scheduled for [-0-9]{10} [:0-9]{8}\.[0-9]+ [+-][0-9]{4} \w{3}\.$

--- a/ignore.d.server/local-snapd
+++ b/ignore.d.server/local-snapd
@@ -1,3 +1,3 @@
 # 16.0.4.2 snapd
-^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ /usr/lib/snapd/snapd\[[0-9]+\]: snapmgr.go:450: No snaps to auto-refresh found$
-^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ snapd\[[0-9]+\]: 20[0-9]+/[0-9]+/[0-9]+ [0-9]+:[0-9]+:[0-9]+\.[0-9]+ snapmgr.go:450: No snaps to auto-refresh found$
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ /usr/lib/snapd/snapd\[[0-9]+\]: snapmgr.go:[0-9]+: No snaps to auto-refresh found$
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ snapd\[[0-9]+\]: [\/0-9]{10} [:0-9]{8}\.[0-9]+ snapmgr.go:[0-9]+: No snaps to auto-refresh found$


### PR DESCRIPTION
snapmgr.go:[0-9]+: instead of snapmgr.go:450:
(said 422 in my logfile so I guess it's just numbers there.)

Also:  2017/08/09 = [\/0-9]{10} and 22:14:44 = [:0-9]{8}