### PR TITLE
Additions to local-systemd (for Ubuntu 20.04

### DIFF
--- a/ignore.d.server/local-snapd
+++ b/ignore.d.server/local-snapd
@@ -1,3 +1,4 @@
 # 16.0.4.2 snapd
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ /usr/lib/snapd/snapd\[[0-9]+\]: snapmgr.go:[0-9]+: No snaps to auto-refresh found$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ snapd\[[0-9]+\]: [\/0-9]{10} [:0-9]{8}\.[0-9]+ snapmgr.go:[0-9]+: No snaps to auto-refresh found$
+^\w{3} [ :0-9]{11} [._[:alnum:]-]+ /usr/lib/snapd/snapd\[[0-9]+\]: snapmgr.go:[0-9]+: DEBUG: Next refresh scheduled for [-0-9]{10} [:0-9]{8}\.[0-9]+ [+-][0-9]{4} \w{3}\.$

--- a/ignore.d.server/local-snapd
+++ b/ignore.d.server/local-snapd
@@ -1,3 +1,3 @@
 # 16.0.4.2 snapd
-^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ /usr/lib/snapd/snapd\[[0-9]+\]: snapmgr.go:450: No snaps to auto-refresh found$
-^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ snapd\[[0-9]+\]: 20[0-9]+/[0-9]+/[0-9]+ [0-9]+:[0-9]+:[0-9]+\.[0-9]+ snapmgr.go:450: No snaps to auto-refresh found$
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ /usr/lib/snapd/snapd\[[0-9]+\]: snapmgr.go:[0-9]+: No snaps to auto-refresh found$
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ snapd\[[0-9]+\]: [\/0-9]{10} [:0-9]{8}\.[0-9]+ snapmgr.go:[0-9]+: No snaps to auto-refresh found$

--- a/ignore.d.server/local-systemd
+++ b/ignore.d.server/local-systemd
@@ -5,7 +5,7 @@
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: (Failed to start|Started|Stopped) User Manager for UID [0-9]+\.$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: user@65534\.service: Start request repeated too quickly\.$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: Started Session [0-9]+ of user [-._[:alnum:]]+\.$
-^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: Starting (Daily apt (upgrade and clean |download)?activities|Clean php session files|Cleanup of Temporary Directories)\.\.\.$
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: Starting (Daily apt (upgrade and clean |download )?activities|Clean php session files|Cleanup of Temporary Directories)\.\.\.$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: (Started|Finished) (Cleanup of Temporary Directories|Daily apt (upgrade and clean |download )?activities|Clean php session files|ACPI event daemon)\.$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: (Created|Removed) slice User Slice of [-._[:alnum:]]+$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: (Reached|Stopped) target (Default|Basic System|Paths|Timers|Sockets)\.$

--- a/ignore.d.server/local-systemd
+++ b/ignore.d.server/local-systemd
@@ -6,7 +6,7 @@
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: user@65534\.service: Start request repeated too quickly\.$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: Started Session [0-9]+ of user [-._[:alnum:]]+\.$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: Starting (Daily apt (upgrade and clean |download )?activities|Clean php session files|Cleanup of Temporary Directories)\.\.\.$
-^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: Started (Cleanup of Temporary Directories|Daily apt (upgrade and clean |download )?activities|Clean php session files|ACPI event daemon)\.$
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: (Started|Finished) (Cleanup of Temporary Directories|Daily apt (upgrade and clean |download )?activities|Clean php session files|ACPI event daemon)\.$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: (Created|Removed) slice User Slice of [-._[:alnum:]]+$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: (Reached|Stopped) target (Default|Basic System|Paths|Timers|Sockets)\.$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: (Reloading|Reloaded|Stopping|Stopped|Starting|Started) LSB: Apache2 web server\.(\.\.)?$

--- a/ignore.d.server/local-systemd
+++ b/ignore.d.server/local-systemd
@@ -5,7 +5,7 @@
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: (Failed to start|Started|Stopped) User Manager for UID [0-9]+\.$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: user@65534\.service: Start request repeated too quickly\.$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: Started Session [0-9]+ of user [-._[:alnum:]]+\.$
-^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: Starting (Daily apt (upgrade and clean |download )?activities|Clean php session files|Cleanup of Temporary Directories)\.\.\.$
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: Starting (Daily apt (upgrade and clean |download)?activities|Clean php session files|Cleanup of Temporary Directories)\.\.\.$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: (Started|Finished) (Cleanup of Temporary Directories|Daily apt (upgrade and clean |download )?activities|Clean php session files|ACPI event daemon)\.$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: (Created|Removed) slice User Slice of [-._[:alnum:]]+$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: (Reached|Stopped) target (Default|Basic System|Paths|Timers|Sockets)\.$
@@ -21,4 +21,7 @@
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: (snapd\.refresh|apt-daily)\.timer: Adding( [0-9]{1,2}h)?( [0-9]{1,2}min)?( [0-9]{1,2}\.[0-9]+s)?( [0-9]{1,3}\.[0-9]{3}ms)? random time\.$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd-timesyncd\[[0-9]+\]: (Timed out waiting for reply from|Synchronized to time server) [.:0-9a-f]+:123 \([._[:alnum:]-]+\)\.$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: (Started|Starting) (Message of the Day\.)(\.\.)?$
-^[[:alpha:]]{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: Stopped Daily apt (download|upgrade and clean) activities\.$
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: Stopped Daily apt (download|upgrade and clean) activities\.$
+# Ubuntu 20.04
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: [a-z0-9-]+\.(service|scope): Succeeded\.$
+


### PR DESCRIPTION
Filter out:

systemd[1]: phpsessionclean.service: Succeeded.
systemd[1]: Finished Clean php session files.
systemd[1]: man-db.service: Succeeded.
systemd[1]: logrotate.service: Succeeded.
systemd[1]: session-2164.scope: Succeeded.