### PR TITLE
Addition to systemd-timesyncd rule, if using IPv6 timeserver

### DIFF
--- a/ignore.d.server/local-systemd
+++ b/ignore.d.server/local-systemd
@@ -19,6 +19,6 @@
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd: pam_unix\(systemd-user:session\): session opened for user [-._[:alnum:]]+ by \(uid=0\)$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd: pam_unix\(systemd-user:session\): session closed for user [-._[:alnum:]]+$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: (snapd\.refresh|apt-daily)\.timer: Adding( [0-9]{1,2}h)?( [0-9]{1,2}min)?( [0-9]{1,2}\.[0-9]+s)?( [0-9]{1,3}\.[0-9]{3}ms)? random time\.$
-^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd-timesyncd\[[0-9]+\]: (Timed out waiting for reply from|Synchronized to time server) [.:0-9a-f]+:123 \([._[:alnum:]-]+\)\.$
+^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd-timesyncd\[[0-9]+\]: (Timed out waiting for reply from|Synchronized to time server) \[?[.:0-9a-f]+\]?:123 \([._[:alnum:]-]+\)\.$
 ^\w{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: (Started|Starting) (Message of the Day\.)(\.\.)?$
 ^[[:alpha:]]{3} [ :[:digit:]]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: Stopped Daily apt (download|upgrade and clean) activities\.$


### PR DESCRIPTION
There are brackets missing if timesyncd uses a IPv6 timeserver.

Example log entries:

May  9 12:31:37 xxxxx systemd-timesyncd[1545]: Timed out waiting for reply from [2001:67c:1560:8003::c8]:123 (ntp.ubuntu.com).
May  9 12:31:38 xxxxx systemd-timesyncd[1545]: Synchronized to time server [2001:67c:1560:8003::c7]:123 (ntp.ubuntu.com).
